### PR TITLE
Replace Node.traverse with Node.findall()

### DIFF
--- a/sphinxcontrib/globalsubs.py
+++ b/sphinxcontrib/globalsubs.py
@@ -42,7 +42,7 @@ class GlobalSubstitutions(SphinxTransform):
         to_handle = (set(global_substitutions.keys())
                 - set(self.document.substitution_defs))
 
-        for ref in self.document.traverse(nodes.substitution_reference):
+        for ref in self.document.findall(nodes.substitution_reference):
             refname = ref['refname']
             if refname in to_handle:
                 text = global_substitutions[refname]


### PR DESCRIPTION
Fix to remove PendingDeprecationWarnings when using docutils-0.18 or newer.

See https://github.com/sphinx-doc/sphinx/pull/10044 for the Sphinx issue that does the change there.