### PR TITLE
Fix TypeError: SphinxComponentRegistry.create_source_parser() takes 2 positional arguments but 3 were given

### DIFF
--- a/sphinxcontrib/globalsubs.py
+++ b/sphinxcontrib/globalsubs.py
@@ -32,7 +32,7 @@ class GlobalSubstitutions(SphinxTransform):
 
     def __init__(self, document, startnode=None):
         super().__init__(document, startnode)
-        self.parser = self.app.registry.create_source_parser(self.app, 'rst')
+        self.parser = self.app.registry.create_source_parser('rst', env=self.document.settings.env, config=self.document.settings.env.config)
 
     def apply(self):
         # type: () -> None


### PR DESCRIPTION
Fixes https://github.com/missinglinkelectronics/sphinxcontrib-globalsubs/issues/5

The new Sphinx release 9.0.0 is not working.

#13639: SphinxComponentRegistry.create_source_parser() no longer has an app parameter, instead taking config and env.
